### PR TITLE
Add login serializer for Swagger

### DIFF
--- a/backend/studyPlannerAPI/serializers.py
+++ b/backend/studyPlannerAPI/serializers.py
@@ -20,6 +20,11 @@ class RegisterSerializer(serializers.Serializer):
             raise serializers.ValidationError("Proszę podać poprawny adres email uczelni (@student.zut.edu.pl)")
         return value
 
+# Serializator do logowania użytkownika (do Swaggera)
+class LoginSerializer(serializers.Serializer):
+    username = serializers.CharField(max_length=150)
+    password = serializers.CharField(max_length=128, write_only=True)
+
 # Serializator, opisujący zwracane dane w Response przy rejestracji użytkownika
 class TokenSerializer(serializers.Serializer):
     refresh = serializers.CharField()

--- a/backend/studyPlannerAPI/views.py
+++ b/backend/studyPlannerAPI/views.py
@@ -10,7 +10,12 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from studyPlannerAPI.models import ModelRequest, CustomUser
-from studyPlannerAPI.serializers import ModelRequestSerializer, RegisterSerializer, TokenSerializer
+from studyPlannerAPI.serializers import (
+    ModelRequestSerializer,
+    RegisterSerializer,
+    LoginSerializer,
+    TokenSerializer,
+)
 from studyPlannerAPI.conversation_context import ConversationContext
 
 from studyPlanner.services import StudyPlanner, DeepseekAIService
@@ -202,6 +207,8 @@ def activate_account(request, uidb64, token):
 
 
 # Logowanie użytkownika
+@swagger_auto_schema(method='post', request_body=LoginSerializer,
+                     responses={200: TokenSerializer()})
 @api_view(['POST'])
 def login_view(request):
     username = request.data.get('username')


### PR DESCRIPTION
## Summary
- extend serializers with LoginSerializer
- document login_view in Swagger using the new serializer

## Testing
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683f581e22dc832182f92559a2d175ca